### PR TITLE
PROD-1452 car hire date time picker does not specify dependancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.2
+
+- Specified `insert-css` as a dependency.
+
 ## v2.0.1
 
 - Transpile fs.readFileSync into inlined string literal.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-group",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Datepicker with optional time",
   "main": "dist/DateTimeGroup.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "url": "https://github.com/holidayextras/react-date-time-group.git"
   },
   "dependencies": {
+    "insert-css": "^0.2.0",
     "moment": "^2.10.6",
     "react": "^0.14.2",
     "react-bootstrap": "^0.28.2",
@@ -39,7 +40,6 @@
     "chai": "^3.3.0",
     "dirty-chai": "^1.2.2",
     "enzyme": "^1.4.1",
-    "insert-css": "^0.2.0",
     "istanbul": "^0.4.2",
     "jsdom": "^3.1.2",
     "make-up": "^7.1.0",


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This work moves the devdependancy `insert-css` to a dependancy.

#### What tests does this PR have?

None.

#### How can this be tested?

Check if CI passes.

It will be tested on the car hire PR (see below).

#### Screenshots / Screencast

#### What gif best describes how you feel about this work?

![giphy](https://cloud.githubusercontent.com/assets/3158640/14301998/30d996e2-fb94-11e5-8427-14c4c9490937.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** \*
- [ ] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru
