### PR TITLE
Add optional props for passing ids to inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.0
+- Add optional props to pass `id` attributes to the date and time inputs
+- Update react-time-select from 2.0.0 to 2.1.0
+
 ## v3.0.0
 
 - Updated react-datepicker version from 0.23.1 to 0.39.0

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ React.render(<DateTimeGroup />, document.getElementById('container'));
 - __dateEnd__ - Date instance representing the latest day selectable
 - __dateExclusions__ - Array of date instances to be "greyed out"
 - __dateFormat__ - Format string used in the calendar header and as the value of the input element
+- __dateId__ - Optional id for the date field.
 
 ### Time options
 
@@ -31,6 +32,7 @@ React.render(<DateTimeGroup />, document.getElementById('container'));
 - __timeStart__ - Time to start from when generating range, for example `start={1230}`. Default is {30} (00:30).
 - __timeEnd__ - Time to stop generating range. Default is {2359}. Will not be listed as an option if your "step" value overruns it.
 - __timeStep__ - Number of minutes between each option. Default is {30}.
+- __timeId__ - Optional id for the time field.
 
 ## Developing
 

--- a/doc/example.js
+++ b/doc/example.js
@@ -42,7 +42,9 @@ fns.render = function() {
         dateExclusions={excludedDates}
         dateFormat="MMMM Do YYYY"
         dateContainerClass="col-xs-12 col-md-8"
-        timeContainerClass="col-xs-12 col-md-4" />
+        timeContainerClass="col-xs-12 col-md-4"
+        dateId="dateWithDateOptions"
+        timeId="timeWithDateOptions" />
 
       <h1>Options for time (value shared with "Events")</h1>
       <DateTimeGroup
@@ -55,7 +57,9 @@ fns.render = function() {
         timeEnd={2130}
         timeStep={15}
         dateContainerClass="col-xs-12 col-md-8"
-        timeContainerClass="col-xs-12 col-md-4" />
+        timeContainerClass="col-xs-12 col-md-4"
+        dateId="dateWithTimeOptions"
+        timeId="timeWithTimeOptions" />
 
       <h1>Events (value shared with "Options for time")</h1>
       <DateTimeGroup value={myDate} onChange={fns.changeDate} />

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-bootstrap": "^0.28.2",
     "react-datepicker": "^0.39.0",
     "react-dom": "^0.14.2",
-    "react-time-select": "^2.0.0"
+    "react-time-select": "^2.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-group",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Datepicker with optional time",
   "main": "dist/DateTimeGroup.js",
   "scripts": {

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -30,7 +30,9 @@ var DateTimeGroup = React.createClass({
     locale: React.PropTypes.string,
     timeContainerClass: React.PropTypes.string,
     dateContainerClass: React.PropTypes.string,
-    readOnly: React.PropTypes.bool
+    readOnly: React.PropTypes.bool,
+    dateId: React.PropTypes.string,
+    timeId: React.PropTypes.string
   },
 
   getDefaultProps: function() {
@@ -87,7 +89,9 @@ var DateTimeGroup = React.createClass({
             start={this.props.timeStart}
             end={this.props.timeEnd}
             step={this.props.timeStep}
-            locale={this.props.locale} />
+            locale={this.props.locale}
+            id={this.props.timeId}
+          />
         </div>
       );
     }
@@ -110,7 +114,9 @@ var DateTimeGroup = React.createClass({
             dateFormat={this.props.dateFormat}
             locales={this.props.locale}
             className="form-control datepicker__input"
-            readOnly={this.props.readOnly} />
+            readOnly={this.props.readOnly}
+            id={this.props.dateId}
+          />
         </div>
         {timePickerColumn}
       </div>

--- a/test/testDateTimeGroup.jsx
+++ b/test/testDateTimeGroup.jsx
@@ -105,6 +105,16 @@ describe('DateTimeGroup', function() {
         it('passes a value prop through', function() {
           expect(dateTimeGroup.find(TimePicker).props().value).to.equal(props.value);
         });
+
+        context('with a timeId prop', function() {
+          beforeEach(function() {
+            dateTimeGroup = shallow(<DateTimeGroup {...props} timeId="timeSelect" />);
+          });
+
+          it('passes an id prop', function() {
+            expect(dateTimeGroup.find(TimePicker).prop('id')).to.equal('timeSelect');
+          });
+        });
       });
 
       context('when not requested', function() {
@@ -191,6 +201,16 @@ describe('DateTimeGroup', function() {
 
         it('renders the date label into a span', function() {
           expect(dateTimeGroup.find('span').children().text()).to.equal('the-date-label');
+        });
+
+        context('with a dateId prop', function() {
+          beforeEach(function() {
+            dateTimeGroup = shallow(<DateTimeGroup {...props} dateId="dateSelect" />);
+          });
+
+          it('passes an id prop to the datepicker', function() {
+            expect(dateTimeGroup.find(DatePicker).prop('id')).to.equal('dateSelect');
+          });
         });
       });
     });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

Adds optional props `dateId` and `timeId` that can be used to pass ids to the input fields.
Also updates the `react-time-select` dependency to `2.1.0` so that it accepts the `id` prop.

#### What tests does this PR have?

```
DateTimeGroup
  time-select child component
        when requested
          with a timeId prop
            ✓ passes an id prop
  date-select child component
        with properties
          with a dateId prop
            ✓ passes an id prop to the datepicker
```

#### How can this be tested?

`npm i` to get the new version of `react-time-select`.
`npm start && open doc/example.html` and check that the `Options for time` and `Options for date` rendered inputs have correct ids.

#### What gif best describes how you feel about this work?
![](https://media.giphy.com/media/qgpO6MRDbGYuc/giphy.gif)

- [ ] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

---

**Reviewer**
- [ ] :+1:
- [ ] This PR need any additional reviewers!

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---