### PR TITLE
Add missing htmlFor to have correct label pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v3.1.1
 - Add missing `htmlFor` to label to pair it correctly with the input
+- Drop react-datepicker version to fix css bug
 
 ## v3.1.0
 - Add optional props to pass `id` attributes to the date and time inputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.1.1
+- Add missing `htmlFor` to label to pair it correctly with the input
+
 ## v3.1.0
 - Add optional props to pass `id` attributes to the date and time inputs
 - Update react-time-select from 2.0.0 to 2.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-group",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Datepicker with optional time",
   "main": "dist/DateTimeGroup.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "moment": "^2.10.6",
     "react": "^0.14.2",
     "react-bootstrap": "^0.28.2",
-    "react-datepicker": "^0.39.0",
+    "react-datepicker": "^0.23.1",
     "react-dom": "^0.14.2",
     "react-time-select": "^2.1.0"
   },

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -100,7 +100,10 @@ var DateTimeGroup = React.createClass({
       <div>
         <div className={this.props.dateContainerClass}>
           {this.props.dateLabel ?
-            <label className="control-label">
+            <label
+              className="control-label"
+              htmlFor={this.props.dateId}
+            >
               <span>{this.props.dateLabel}</span>
             </label>
           : ''}

--- a/test/testDateTimeGroup.jsx
+++ b/test/testDateTimeGroup.jsx
@@ -205,11 +205,15 @@ describe('DateTimeGroup', function() {
 
         context('with a dateId prop', function() {
           beforeEach(function() {
-            dateTimeGroup = shallow(<DateTimeGroup {...props} dateId="dateSelect" />);
+            dateTimeGroup = shallow(<DateTimeGroup {...props} dateId="dateSelect" dateLabel="the-date-label" />);
           });
 
           it('passes an id prop to the datepicker', function() {
             expect(dateTimeGroup.find(DatePicker).prop('id')).to.equal('dateSelect');
+          });
+
+          it('renders a paired label', function() {
+            expect(dateTimeGroup.find('label').prop('htmlFor')).to.equal('dateSelect');
           });
         });
       });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

When the id prop was added in #9 the paired `htmlFor` prop was missed on the label. This adds that prop in so that our labels and inputs are correctly paired.

#### How can this be tested?

Follow the same instructions as on #9 and check the label has a `for` attribute for the correct input.

#### What gif best describes how you feel about this work?
![](https://media.giphy.com/media/gnJgBlPgHtcnS/giphy.gif)

- [ ] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

---

**Reviewer**
- [ ] :+1:
- [ ] This PR need any additional reviewers!

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---