### PR TITLE
Prod 1641 - Adds support for Minute / Hour time inputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.0
+- Add `seperateHourMins` prop for splitting hours and minutes into individual inputs.
+- Add `time` object prop for setting minutes and hour values.
+
 ## v3.1.1
 - Add missing `htmlFor` to label to pair it correctly with the input
 - Drop react-datepicker version to fix css bug

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ React.render(<DateTimeGroup />, document.getElementById('container'));
 - __timeEnd__ - Time to stop generating range. Default is {2359}. Will not be listed as an option if your "step" value overruns it.
 - __timeStep__ - Number of minutes between each option. Default is {30}.
 - __timeId__ - Optional id for the time field.
+- __seperateHourMins__ - Optional toggle for seperating hour and minutes into seperate inputs.
+- __time__ - Time object of hours / minutes to set values of seperate hours and minutes inputs.
 
 ## Developing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-group",
-  "version": "3.2.1",
+  "version": "3.2.0",
   "description": "Datepicker with optional time",
   "main": "dist/DateTimeGroup.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-group",
-  "version": "3.1.1",
+  "version": "3.2.1",
   "description": "Datepicker with optional time",
   "main": "dist/DateTimeGroup.js",
   "scripts": {
@@ -25,7 +25,7 @@
     "react-bootstrap": "^0.28.2",
     "react-datepicker": "^0.23.1",
     "react-dom": "^0.14.2",
-    "react-time-select": "^2.1.0"
+    "react-time-select": "^2.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -20,7 +20,10 @@ var DateTimeGroup = React.createClass({
     onChange: React.PropTypes.func,
     onTimeChange: React.PropTypes.func,
     timeStart: React.PropTypes.number,
-    time: React.PropTypes.object,
+    time: React.PropTypes.shape({
+      hours: React.PropTypes.string,
+      minutes: React.PropTypes.string
+    }),
     timeEnd: React.PropTypes.number,
     timeStep: React.PropTypes.number,
     dateName: React.PropTypes.string,
@@ -47,7 +50,11 @@ var DateTimeGroup = React.createClass({
       dateName: 'Date',
       value: defaultDate,
       locale: 'en-GB',
-      seperateHourMins: false
+      seperateHourMins: false,
+      time: {
+        hours: '12',
+        minutes: '00'
+      }
     };
   },
 

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -18,7 +18,9 @@ var DateTimeGroup = React.createClass({
     timeName: React.PropTypes.string,
     value: React.PropTypes.instanceOf(Date),
     onChange: React.PropTypes.func,
+    onTimeChange: React.PropTypes.func,
     timeStart: React.PropTypes.number,
+    time: React.PropTypes.object,
     timeEnd: React.PropTypes.number,
     timeStep: React.PropTypes.number,
     dateName: React.PropTypes.string,
@@ -32,7 +34,8 @@ var DateTimeGroup = React.createClass({
     dateContainerClass: React.PropTypes.string,
     readOnly: React.PropTypes.bool,
     dateId: React.PropTypes.string,
-    timeId: React.PropTypes.string
+    timeId: React.PropTypes.string,
+    seperateHourMins: React.PropTypes.bool
   },
 
   getDefaultProps: function() {
@@ -43,7 +46,8 @@ var DateTimeGroup = React.createClass({
       includeTime: true,
       dateName: 'Date',
       value: defaultDate,
-      locale: 'en-GB'
+      locale: 'en-GB',
+      seperateHourMins: false
     };
   },
 
@@ -51,6 +55,22 @@ var DateTimeGroup = React.createClass({
     if (this.props.onChange) {
       this.props.onChange(newDateTime);
     }
+  },
+
+  minutesHoursChanged: function(time) {
+    var newDate = this.props.value;
+
+    if (time.hours) {
+      newDate.setHours(time.hours);
+      this.props.time.hours = time.hours;
+    }
+
+    if (time.minutes) {
+      newDate.setMinutes(time.minutes);
+      this.props.time.minutes = time.minutes;
+    }
+
+    this.props.onTimeChange(newDate);
   },
 
   dateChanged: function(newMoment) {
@@ -84,13 +104,16 @@ var DateTimeGroup = React.createClass({
             className={this.props.timeClassName}
             label={this.props.timeLabel}
             name={this.props.timeName}
+            time={this.props.time}
             value={this.props.value}
             onChange={this.timeChanged}
+            minutesHoursChanged={this.minutesHoursChanged}
             start={this.props.timeStart}
             end={this.props.timeEnd}
             step={this.props.timeStep}
             locale={this.props.locale}
             id={this.props.timeId}
+            seperateHourMins={this.props.seperateHourMins}
           />
         </div>
       );
@@ -106,7 +129,7 @@ var DateTimeGroup = React.createClass({
             >
               <span>{this.props.dateLabel}</span>
             </label>
-          : ''}
+            : ''}
           <DatePicker
             name={this.props.dateName}
             selected={moment(this.props.value)}

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -51,24 +51,13 @@ var DateTimeGroup = React.createClass({
     };
   },
 
-  timeChanged: function(newDateTime) {
-    if (this.props.onChange) {
-      this.props.onChange(newDateTime);
-    }
-  },
-
-  minutesHoursChanged: function(time) {
+  timeChanged: function(time) {
     var newDate = this.props.value;
+    newDate.setHours(time.hours);
+    this.props.time.hours = time.hours;
 
-    if (time.hours) {
-      newDate.setHours(time.hours);
-      this.props.time.hours = time.hours;
-    }
-
-    if (time.minutes) {
-      newDate.setMinutes(time.minutes);
-      this.props.time.minutes = time.minutes;
-    }
+    newDate.setMinutes(time.minutes);
+    this.props.time.minutes = time.minutes;
 
     this.props.onTimeChange(newDate);
   },
@@ -107,7 +96,6 @@ var DateTimeGroup = React.createClass({
             time={this.props.time}
             value={this.props.value}
             onChange={this.timeChanged}
-            minutesHoursChanged={this.minutesHoursChanged}
             start={this.props.timeStart}
             end={this.props.timeEnd}
             step={this.props.timeStep}

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -59,14 +59,15 @@ var DateTimeGroup = React.createClass({
   },
 
   timeChanged: function(time) {
-    var newDate = this.props.value;
-    newDate.setHours(time.hours);
-    this.props.time.hours = time.hours;
+    if (this.props.onTimeChange) {
+      var newDate = this.props.value;
+      newDate.setHours(time.hours);
+      this.props.time.hours = time.hours;
 
-    newDate.setMinutes(time.minutes);
-    this.props.time.minutes = time.minutes;
-
-    this.props.onTimeChange(newDate);
+      newDate.setMinutes(time.minutes);
+      this.props.time.minutes = time.minutes;
+      this.props.onTimeChange(newDate);
+    }
   },
 
   dateChanged: function(newMoment) {

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -65,7 +65,7 @@ var DateTimeGroup = React.createClass({
   dateChanged: function(newMoment) {
     if (this.props.onChange) {
       var newDate = newMoment.toDate();
-      newDate.setHours(this.props.value.getHours(), this.props.value.getMinutes(), 0, 0);
+      newDate.setHours(this.props.time.hours, this.props.time.minutes, 0, 0);
 
       this.props.onChange(newDate);
     }

--- a/test/testDateTimeGroup.jsx
+++ b/test/testDateTimeGroup.jsx
@@ -39,7 +39,12 @@ describe('DateTimeGroup', function() {
         dateName: 'Date',
         includeTime: true,
         value: new Date(2015, 5, 6, 12, 0, 0),
-        locale: 'en-GB'
+        locale: 'en-GB',
+        seperateHourMins: false,
+        time: {
+          hours: '12',
+          minutes: '00'
+        }
       });
     });
   });
@@ -221,31 +226,43 @@ describe('DateTimeGroup', function() {
   });
 
   describe('events', function() {
-    it('will emit a date up if the time is changed', function() {
-      var handler = sinon.stub();
-      var doc = TestUtils.renderIntoDocument(<DateTimeGroup onChange={handler} />);
-      var node = TestUtils.findRenderedDOMComponentWithTag(doc, 'select');
+    var props;
 
-      TestUtils.Simulate.change(node, {
-        target: {
-          value: '16:30'
+    beforeEach(function() {
+      props = {
+        time: {
+          hours: '11',
+          minutes: '30'
         }
-      });
-
-      sinon.assert.calledWith(handler, new Date(2015, 5, 6, 16, 30, 0, 0));
+      };
     });
 
     it('will emit a date up if the date is changed', function() {
-      var date = new Date(2015, 5, 5, 11, 30, 0, 0);
+      var date = new Date(2015, 5, 5);
       var handler = sinon.stub();
 
-      var dateTimeGroup = shallow(<DateTimeGroup onChange={handler} value={date} />);
+      var dateTimeGroup = shallow(<DateTimeGroup onChange={handler} {...props} value={date} />);
       var input = dateTimeGroup.find('.datepicker__input');
 
       input.simulate('change', moment('2015-06-12'));
 
       sinon.assert.called(handler);
       sinon.assert.calledWith(handler, new Date(2015, 5, 12, 11, 30, 0, 0));
+    });
+
+    it('will emit current time up with date when changed', function() {
+      props.time.hours = '15';
+      props.time.minutes = '30';
+      var date = new Date(2015, 5, 5);
+      var handler = sinon.stub();
+
+      var dateTimeGroup = shallow(<DateTimeGroup onChange={handler} {...props} value={date} />);
+      var input = dateTimeGroup.find('.datepicker__input');
+
+      input.simulate('change', moment('2015-06-12'));
+
+      sinon.assert.called(handler);
+      sinon.assert.calledWith(handler, new Date(2015, 5, 12, 15, 30, 0, 0));
     });
 
     it('will not throw errors if no onClick is provided (for date)', function() {
@@ -271,7 +288,5 @@ describe('DateTimeGroup', function() {
         });
       }).to.not.throw(Error);
     });
-
-    context();
   });
 });

--- a/test/testDateTimeGroup.jsx
+++ b/test/testDateTimeGroup.jsx
@@ -271,5 +271,7 @@ describe('DateTimeGroup', function() {
         });
       }).to.not.throw(Error);
     });
+
+    context();
   });
 });

--- a/test/testDateTimeGroup.jsx
+++ b/test/testDateTimeGroup.jsx
@@ -237,6 +237,8 @@ describe('DateTimeGroup', function() {
       };
     });
 
+
+
     it('will emit a date up if the date is changed', function() {
       var date = new Date(2015, 5, 5);
       var handler = sinon.stub();
@@ -265,8 +267,26 @@ describe('DateTimeGroup', function() {
       sinon.assert.calledWith(handler, new Date(2015, 5, 12, 15, 30, 0, 0));
     });
 
-    it('will not throw errors if no onClick is provided (for date)', function() {
+    it('will emit time up when time changed', function() {
+      props.seperateHourMins = true;
+      props.includeTime = true;
+      props.value = new Date(2015, 5, 5);
+      var handler = sinon.stub();
 
+      var doc = TestUtils.renderIntoDocument(<DateTimeGroup onTimeChange={handler} {...props} />);
+      var timeNode = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'select')[1];
+
+      TestUtils.Simulate.change(timeNode, {
+        target: {
+          value: '15'
+        }
+      });
+
+      sinon.assert.called(handler);
+      sinon.assert.calledWith(handler, new Date(2015, 5, 5, 11, 15, 0, 0));
+    });
+
+    it('will not throw errors if no onClick is provided (for date)', function() {
       var dateTimeGroup = shallow(<DateTimeGroup />);
       var input = dateTimeGroup.find('.datepicker__input');
 


### PR DESCRIPTION
**What does this PR do? (please provide any background)**

Adds support for having seperate hours and minute inputs (https://github.com/holidayextras/react-time-select/pull/12).

- Bumps version for `react-time-select`.

**What tests does this PR have?**
None. 

Todo: Update unit tests.

**How can this be tested?**
To locally test this you will need to reference each repo's branch in the package.json. This is a bit of a pain, so I can show you on my machine if that's preferred.

**Any tech debt?**
No.