### PR TITLE
PROD-2239 Call the onChange prop callback when time is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.2.3
+- Fix the callback from the `onChange` prop to be called on changing time
+
 ## v3.2.2
 - Update react-time-select from 2.2.0 to 2.2.1.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-group",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Datepicker with optional time",
   "main": "dist/DateTimeGroup.js",
   "scripts": {

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -59,14 +59,20 @@ var DateTimeGroup = React.createClass({
   },
 
   timeChanged: function(time) {
-    if (this.props.onTimeChange) {
-      var newDate = this.props.value;
-      newDate.setHours(time.hours);
-      this.props.time.hours = time.hours;
 
-      newDate.setMinutes(time.minutes);
-      this.props.time.minutes = time.minutes;
+    this.props.time.hours = time.hours;
+    this.props.time.minutes = time.minutes;
+
+    const newDate = this.props.value;
+    newDate.setHours(time.hours);
+    newDate.setMinutes(time.minutes);
+
+    if (this.props.onTimeChange) {
       this.props.onTimeChange(newDate);
+    }
+
+    if (this.props.onChange) {
+      this.props.onChange(newDate);
     }
   },
 

--- a/test/testDateTimeGroup.jsx
+++ b/test/testDateTimeGroup.jsx
@@ -237,8 +237,6 @@ describe('DateTimeGroup', function() {
       };
     });
 
-
-
     it('will emit a date up if the date is changed', function() {
       var date = new Date(2015, 5, 5);
       var handler = sinon.stub();
@@ -271,9 +269,13 @@ describe('DateTimeGroup', function() {
       props.seperateHourMins = true;
       props.includeTime = true;
       props.value = new Date(2015, 5, 5);
-      var handler = sinon.stub();
 
-      var doc = TestUtils.renderIntoDocument(<DateTimeGroup onTimeChange={handler} {...props} />);
+      const expectedCurrentTime = new Date(2015, 5, 5, 11, 15, 0, 0);
+
+      var timeHandler = sinon.stub();
+      var dateHandler = sinon.stub();
+
+      var doc = TestUtils.renderIntoDocument(<DateTimeGroup onTimeChange={timeHandler} onChange={dateHandler} {...props} />);
       var timeNode = TestUtils.scryRenderedDOMComponentsWithTag(doc, 'select')[1];
 
       TestUtils.Simulate.change(timeNode, {
@@ -282,8 +284,8 @@ describe('DateTimeGroup', function() {
         }
       });
 
-      sinon.assert.called(handler);
-      sinon.assert.calledWith(handler, new Date(2015, 5, 5, 11, 15, 0, 0));
+      sinon.assert.calledWith(timeHandler, expectedCurrentTime);
+      sinon.assert.calledWith(dateHandler, expectedCurrentTime);
     });
 
     it('will not throw errors if no onClick is provided (for date)', function() {


### PR DESCRIPTION
**What does this PR do? (please provide any background)**
Currently when using the `react-date-time-group` component from inside a [react-date-time-range](https://github.com/holidayextras/react-date-time-range) changing the time fields does not work. That is because the callback attached to the `onChange` prop is not called when the **time** fields values are changed (but is called when the **date** fields values are changed). This PR adds a fix for calling the `onChange` prop callback when **time** is changed.

**What tests does this PR have?**
Updated unit tests.

**How can this be tested?**
1. You need the [Car Hire engine](https://github.com/holidayextras/tripapp-product-carhire) deployed locally:
`git clone git@github.com:holidayextras/tripapp-product-carhire.git`
2. Then you have to do the following changes in `package.json`:
- `"react-bootstrap": "^0.30.1",` -> `"react-bootstrap": "0.30.1",` (this is needed because the current `react-bootsrap@0.30.9` version released yesterday breaks engine builds)
- `"react-date-time-group": "^2.0.2",` -> `"react-date-time-group": "git://github.com/holidayextras/react-date-time-group.git#PROD-2239",`
3. Re-install all node module dependencies for the engine: `rm -rf node_modules && npm install`
4. Rebuild the `node_modules/react-date-time-group/dist` directory from inside the engine:
```
cd ./node_modules/react-date-time-group
nvm use
npm install
npm run prepublish
```
5. Rebuild the **Car Hire** engine: `npm run build:umd:engine`
6. Open the **Car Hire** engine example page `example/standalone.html` in a web browser and check that changing the **Pick up time** and **Drop off time** field values work as expected as well as the **Pick up date** / **Drop off date** fields behaviour is not affected in any way. There should not be any errors in the javascript console.

**Any tech debt?**
N/A