### PR TITLE
PROD-2316 Remove `insert-css`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v4.0.0
+- Remove the `insert-css` dependency. The CSS should be linked explicitly.
+
 ## v3.2.3
 - Fix the callback from the `onChange` prop to be called on changing time
 

--- a/doc/example.html
+++ b/doc/example.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>DateTime group</title>
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet" integrity="sha256-MfvZlkHCEqatNoGiOXveE8FIwMzZg4W85qfrfIFBfYc= sha512-dTfge/zgoMYpP7QbHy4gWMEGsbsdZeCXz7irItjcC3sPUFtf0kuFbDz/ixG7ArTxmDjLXDmezHubeNikyKGVyQ==" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="../dist/date-time-group.css" />
   </head>
   <body>
     <div id="container">

--- a/doc/example.js
+++ b/doc/example.js
@@ -1,10 +1,5 @@
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var insertcss = require('insert-css');
-insertcss(fs.readFileSync(path.join(__dirname, '/../dist/date-time-group.css'), 'utf8'));
-
 var React = require('react');
 var ReactDOM = require('react-dom');
 var DateTimeGroup = require('../src/DateTimeGroup.jsx');

--- a/doc/example.js
+++ b/doc/example.js
@@ -1,5 +1,10 @@
 'use strict';
 
+var fs = require('fs');
+var path = require('path');
+var insertcss = require('insert-css');
+insertcss(fs.readFileSync(path.join(__dirname, '/../dist/date-time-group.css'), 'utf8'));
+
 var React = require('react');
 var ReactDOM = require('react-dom');
 var DateTimeGroup = require('../src/DateTimeGroup.jsx');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepublish": "mkdir -p ./dist && babel ./src/DateTimeGroup.jsx > ./dist/DateTimeGroup.js && npm run less",
     "less": "mkdir -p ./dist && lessc ./src/date-time-group.less ./dist/date-time-group.css",
     "prestart": "ulimit -n 9999",
-    "start": "watchify -t babelify doc/example.js -o doc/example-built.js -v",
+    "start": "npm run less && watchify -t babelify doc/example.js -o doc/example-built.js -v",
     "test": "mocha --require react-tests-globals-setup --compilers js:babel-core/register test/test*",
     "lint": "make-up src test doc"
   },
@@ -20,7 +20,6 @@
     "url": "https://github.com/holidayextras/react-date-time-group.git"
   },
   "dependencies": {
-    "insert-css": "^0.2.0",
     "moment": "^2.10.6",
     "react": "^0.14.2",
     "react-bootstrap": "^0.28.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "enzyme": "^1.4.1",
     "istanbul": "^0.4.2",
     "jsdom": "^3.1.2",
+    "less": "2.7.2",
     "make-up": "^7.1.0",
     "mocha": "^2.3.3",
     "react-addons-test-utils": "^0.14.6",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/holidayextras/react-date-time-group.git"
   },
   "dependencies": {
+    "insert-css": "^0.2.0",
     "moment": "^2.10.6",
     "react": "^0.14.2",
     "react-bootstrap": "^0.28.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "ci": "npm run lint && npm run coverage",
     "coverage": "babel-node node_modules/.bin/babel-istanbul cover node_modules/.bin/_mocha -- --require react-tests-globals-setup test/test* && istanbul check-coverage",
-    "prepublish": "mkdir -p ./dist && babel ./src/DateTimeGroup.jsx > ./dist/DateTimeGroup.js",
+    "prepublish": "mkdir -p ./dist && babel ./src/DateTimeGroup.jsx > ./dist/DateTimeGroup.js && npm run less",
+    "less": "mkdir -p ./dist && lessc --include-path=../../ ./src/date-time-group.less ./dist/date-time-group.css",
     "prestart": "ulimit -n 9999",
     "start": "watchify -t babelify doc/example.js -o doc/example-built.js -v",
     "test": "mocha --require react-tests-globals-setup --compilers js:babel-core/register test/test*",
@@ -19,7 +20,6 @@
     "url": "https://github.com/holidayextras/react-date-time-group.git"
   },
   "dependencies": {
-    "insert-css": "^0.2.0",
     "moment": "^2.10.6",
     "react": "^0.14.2",
     "react-bootstrap": "^0.28.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-group",
-  "version": "3.2.3",
+  "version": "4.0.0",
   "description": "Datepicker with optional time",
   "main": "dist/DateTimeGroup.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ci": "npm run lint && npm run coverage",
     "coverage": "babel-node node_modules/.bin/babel-istanbul cover node_modules/.bin/_mocha -- --require react-tests-globals-setup test/test* && istanbul check-coverage",
     "prepublish": "mkdir -p ./dist && babel ./src/DateTimeGroup.jsx > ./dist/DateTimeGroup.js && npm run less",
-    "less": "mkdir -p ./dist && lessc --include-path=../../ ./src/date-time-group.less ./dist/date-time-group.css",
+    "less": "mkdir -p ./dist && lessc ./src/date-time-group.less ./dist/date-time-group.css",
     "prestart": "ulimit -n 9999",
     "start": "watchify -t babelify doc/example.js -o doc/example-built.js -v",
     "test": "mocha --require react-tests-globals-setup --compilers js:babel-core/register test/test*",

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -2,9 +2,6 @@
 
 var fs = require('fs');
 var path = require('path');
-var insertcss = require('insert-css');
-insertcss(fs.readFileSync(path.join(__dirname, '/../node_modules/react-datepicker/dist/react-datepicker.css'), 'utf8'));
-
 var React = require('react');
 var TimePicker = require('react-time-select');
 var DatePicker = require('react-datepicker');

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -1,7 +1,5 @@
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
 var React = require('react');
 var TimePicker = require('react-time-select');
 var DatePicker = require('react-datepicker');

--- a/src/date-time-group.less
+++ b/src/date-time-group.less
@@ -1,0 +1,1 @@
+@import (less) 'node_modules/react-datepicker/dist/react-datepicker.css';


### PR DESCRIPTION
**What does this PR do? (please provide any background)**
The component currently does not have any styling, but since it relies on the `react-datepicker` it must expose the `react-datepicker`'s CSS somehow. It does that using `insert-css` which implicitly injects the CSS file content into a dynamically created `<style>` attached the `document.head`. While that might be convenient for saving us one additional step of 'require'-ing a CSS, it brings some issues. One of the issue we bumped into is that the `insert-css` mechanism doesn't work server-side (in static-site-generator), because there seems to be no `document` object where the `react-datepicker`'s CSS file has to be inserted (resulting in a `Uncaught ReferenceError: document is not defined` error).

This PR removes the `insert-css` module and it's way of exposing the component's styling, and adds a separate `date-time-group.less` file (which imports the `react-datepicker`'s style). That `date-time-group.less` file is then exposed by building a `date-time-group.css` file in the component's `dist` directory along with the compiled `DateTimeGroup.jsx` (pretty much similar to what `react-datepicker` does with it's own styling).  This way the component has it's own style, which must be explicitly 'required'. A major version bump is done for this change in order not to break usages of versions with the current `insert-css` implementation.

Here is a [PR](https://github.com/holidayextras/tripapp-product-resorttransfers/pull/57) with how the `react-date-time-group` component css will be used in the **Resort Transfers** engine. It can be tested without publishing `react-date-time-group` by replacing the following line in the **Resort Transfers** engine's `package.json`
```
"react-date-time-group": "4.0.0",
```
with
```
"react-date-time-group": "git+ssh://git@github.com:holidayextras/react-date-time-group.git#PROD-2316",
```
and then running `npm install` from within `node_modules/react-date-time-group`.

**What tests does this PR have?**
N/A

**How can this be tested?**
1. Checkout the this branch: `git checkout PROD-2316`
2. Do a clean npm install: `rm -rf node_modules && npm install`
3. Build the component's `jsx` and `less` files: `rm -rf dist && npm run prepublish`
Make sure that there are both `DateTimeGroup.js` and `date-time-group.css` in the `dist` directory
4. Build the component's example: `npm run start`
Open the `doc/example.html` file in your browser and check that the calendar date picker styling is ok.

**Any tech debt?**
N/A