### PR TITLE
Add Props that allow the showing of the month and year dropdowns in the calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## V4.2.0
+- Add showMonthDropdown prop for showing a month dropdown
+- Add showYearDropdown prop for showing a year dropdown
+
 ## v4.1.1
 - Update react-datepicker from 0.23.1 to 0.39.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v4.1.1
+- Update react-datepicker from 0.23.1 to 0.39.0
+
 ## v4.1.0
 - Update react-time-select from 2.2.1 to 2.3.0.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ React.render(<DateTimeGroup />, document.getElementById('container'));
 - __dateExclusions__ - Array of date instances to be "greyed out"
 - __dateFormat__ - Format string used in the calendar header and as the value of the input element
 - __dateId__ - Optional id for the date field.
+- __showMonthDropdown__ - Show a month dropdown on the calendar.
+- __showYearDropdown__ - Shows a year dropdown on the calendar.
 
 ### Time options
 

--- a/doc/example.js
+++ b/doc/example.js
@@ -44,7 +44,9 @@ fns.render = function() {
         dateContainerClass="col-xs-12 col-md-8"
         timeContainerClass="col-xs-12 col-md-4"
         dateId="dateWithDateOptions"
-        timeId="timeWithDateOptions" />
+        timeId="timeWithDateOptions"
+        showMonthDropdown={true}
+        showYearDropdown={true} />
 
       <h1>Options for time (value shared with "Events")</h1>
       <DateTimeGroup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-group",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Datepicker with optional time",
   "main": "dist/DateTimeGroup.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "moment": "^2.10.6",
     "react": "^0.14.2",
     "react-bootstrap": "^0.28.2",
-    "react-datepicker": "^0.23.1",
+    "react-datepicker": "0.39.0",
     "react-dom": "^0.14.2",
     "react-time-select": "^2.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-group",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Datepicker with optional time",
   "main": "dist/DateTimeGroup.js",
   "scripts": {

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -128,6 +128,7 @@ var DateTimeGroup = React.createClass({
             </label>
             : ''}
           <DatePicker
+            fixedHeight={true}
             name={this.props.dateName}
             selected={moment(this.props.value)}
             onChange={this.dateChanged}

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -129,6 +129,8 @@ var DateTimeGroup = React.createClass({
             : ''}
           <DatePicker
             fixedHeight={true}
+            showMonthDropdown={this.props.showMonthDropdown}
+            showYearDropdown={this.props.showYearDropdown}
             name={this.props.dateName}
             selected={moment(this.props.value)}
             onChange={this.dateChanged}
@@ -149,3 +151,4 @@ var DateTimeGroup = React.createClass({
 });
 
 module.exports = DateTimeGroup;
+

--- a/src/date-time-group.less
+++ b/src/date-time-group.less
@@ -1,1 +1,49 @@
 @import (less) 'node_modules/react-datepicker/dist/react-datepicker.css';
+
+// Match older styling changes
+.react-datepicker__input-container {
+  display: block;
+}
+
+.react-datepicker {
+  font-size: 1em;
+}
+.react-datepicker__header {
+  padding-top: 0.8em;
+}
+.react-datepicker__month {
+  margin: 0.4em 1em;
+}
+.react-datepicker__day-name, .react-datepicker__day {
+  width: 1.5em;
+  line-height: 1.5em;
+  margin: 0.166em;
+}
+.react-datepicker__current-month {
+  font-size: 1em;
+}
+.react-datepicker__navigation {
+  top: 1em;
+  line-height: 1.3em;
+  border: 0.45em solid transparent;
+}
+.react-datepicker__navigation--previous {
+  border-right-color: #ccc;
+  left: 1em;
+}
+.react-datepicker__navigation--next {
+  border-left-color: #ccc;
+  right: 1em;
+}
+
+.react-datepicker-time__header {
+  font-size: 0.944em;
+}
+
+.react-datepicker__navigation--next--with-time {
+  right: 80px;
+}
+
+.react-datepicker__time-list-item {
+  width: 50px;
+}


### PR DESCRIPTION
Adds two new props that when set to true show dropdowns on the calendar which allow the user to jump between months/years quicker.

To test this run `npm start` and check out the date section of the examples.