### PR TITLE
Removing plural from local

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-date-time-group",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Datepicker with optional time",
   "main": "dist/DateTimeGroup.js",
   "scripts": {

--- a/src/DateTimeGroup.jsx
+++ b/src/DateTimeGroup.jsx
@@ -91,7 +91,7 @@ class DateTimeGroup extends React.Component {
             maxDate={this.props.dateEnd ? moment(this.props.dateEnd) : null}
             excludeDates={this.dateExclusions()}
             dateFormat={this.props.dateFormat}
-            locales={this.props.locale}
+            locale={this.props.locale}
             className='form-control datepicker__input'
             readOnly={this.props.readOnly}
             id={this.props.dateId}

--- a/test/testDateTimeGroup.jsx
+++ b/test/testDateTimeGroup.jsx
@@ -181,7 +181,7 @@ describe('DateTimeGroup', function () {
         })
 
         it('passes the first locale through (only one is expected)', function () {
-          expect(dateTimeGroup.find(DatePicker).props().locales).to.equal('en-US')
+          expect(dateTimeGroup.find(DatePicker).props().locale).to.equal('en-US')
         })
 
         it('wraps the value in a moment', function () {


### PR DESCRIPTION
This repo uses https://reactdatepicker.com/ 
to get the calendar start on a monday instead of sunday you need to pass through a locale.
https://reactdatepicker.com/#example-15

This requires locale instead of locales which appears in this repo.
This PR changes it to use the right prop.